### PR TITLE
Update SAUCE_VERSION to 4.6.2

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 FROM alpine:3.10 as build
 
-ENV SAUCE_VERSION 4.5.4
+ENV SAUCE_VERSION 4.6.2
 
 RUN apk update && apk add wget && rm -rf /var/cache/apk/*
 

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ An example with `docker-compose` on how to use it for integration testing with `
 ## Versions
 
 * `latest`
-* `4.5`
+* `4.6.2`
 
 ## Usage
 


### PR DESCRIPTION
Tested.
Note that usage for Selenium-based tests requires an additional --se-port command line option.
See https://wiki.saucelabs.com/display/DOCS/Sauce+Connect+Proxy+Change+Logs